### PR TITLE
refactor: using `log` not `tracing`

### DIFF
--- a/.template/Cargo.toml.liquid
+++ b/.template/Cargo.toml.liquid
@@ -15,7 +15,7 @@ helper.workspace = true
 
 anyhow.workspace = true
 dotenv.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true

--- a/.template/src/bin/client.rs.liquid
+++ b/.template/src/bin/client.rs.liquid
@@ -1,14 +1,15 @@
 use anyhow::Result;
 use helper::util::client::get_client;
 use helper::client_ext::ClientExt;
+use log::info;
 use nanoid::nanoid;
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk_core::protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/.template/src/bin/main.rs.liquid
+++ b/.template/src/bin/main.rs.liquid
@@ -4,6 +4,7 @@ use {{ project-name | snake_case }}::worker;
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await
 }

--- a/.template/src/workflows.rs.liquid
+++ b/.template/src/workflows.rs.liquid
@@ -1,7 +1,7 @@
 use crate::activities::greet;
 use helper::activity_resolution_ext::ActivityResolutionExt;
 use helper::wf_context_ext::{ProxyActivityOptions, WfContextExt};
-use tracing::info;
+use log::info;
 use std::time::Duration;
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core::protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "temporal-client",
  "temporal-sdk",
@@ -16,8 +18,6 @@ dependencies = [
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -26,7 +26,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "prost-wkt-types",
  "reqwest",
@@ -37,8 +39,6 @@ dependencies = [
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -323,15 +323,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "temporal-client",
  "temporal-sdk",
  "temporal-sdk-core",
  "temporal-sdk-core-protos",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -361,15 +361,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "temporal-client",
  "temporal-sdk",
  "temporal-sdk-core",
  "temporal-sdk-core-protos",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2156,14 +2156,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "temporal-client",
  "temporal-sdk",
  "temporal-sdk-core",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -2180,7 +2180,9 @@ dependencies = [
  "anyhow",
  "chrono",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "serde",
  "serde_json",
@@ -2189,8 +2191,6 @@ dependencies = [
  "temporal-sdk-core",
  "temporal-sdk-core-protos",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,14 +947,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "helper",
+ "log",
  "nanoid",
  "temporal-client",
  "temporal-sdk",
  "temporal-sdk-core",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/activities-cancellation-heartbeating/Cargo.toml
+++ b/activities-cancellation-heartbeating/Cargo.toml
@@ -16,8 +16,8 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true
 

--- a/activities-cancellation-heartbeating/src/activities/fake_progress.rs
+++ b/activities-cancellation-heartbeating/src/activities/fake_progress.rs
@@ -1,7 +1,7 @@
+use log::info;
 use std::time::Duration;
 use temporal_sdk::{ActContext, ActivityError};
 use temporal_sdk_core::protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
-use tracing::info;
 
 pub async fn fake_progress(ctx: ActContext, sleep_interval_ms: u64) -> Result<u64, ActivityError> {
     // allow for resuming from heartbeat

--- a/activities-cancellation-heartbeating/src/bin/client.rs
+++ b/activities-cancellation-heartbeating/src/bin/client.rs
@@ -1,14 +1,15 @@
 use helper::client_ext::ClientExt;
 use helper::get_client;
+use log::info;
 use std::time::Duration;
 use temporal_client::WorkflowOptions;
 use temporal_sdk_core::protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core::WorkflowClientTrait;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/activities-cancellation-heartbeating/src/bin/main.rs
+++ b/activities-cancellation-heartbeating/src/bin/main.rs
@@ -5,6 +5,7 @@ use activities_cancellation_heartbeating::worker;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await?;
     Ok(())

--- a/activities-cancellation-heartbeating/src/workflows.rs
+++ b/activities-cancellation-heartbeating/src/workflows.rs
@@ -1,4 +1,4 @@
-use tracing::info;
+use log::info;
 
 use crate::activities::fake_progress;
 use helper::activity_resolution_ext::ActivityResolutionExt;

--- a/activities-examples/Cargo.toml
+++ b/activities-examples/Cargo.toml
@@ -16,8 +16,8 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio = { workspace = true, features = ["time"]}
 nanoid.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/activities-examples/src/activities/async_completion.rs
+++ b/activities-examples/src/activities/async_completion.rs
@@ -1,12 +1,12 @@
 use helper::get_client;
 use helper::util::activity_input::ActivityInput;
+use log::info;
 use std::time::Duration;
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk::{ActContext, ActExitValue, ActivityError};
 use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core_protos::TaskToken;
 use tokio::time::timeout;
-use tracing::info;
 
 pub async fn do_something_async(
     ctx: ActContext,

--- a/activities-examples/src/activities/make_http_request.rs
+++ b/activities-examples/src/activities/make_http_request.rs
@@ -1,7 +1,7 @@
 use helper::util::activity_input::ActivityInput;
+use log::info;
 use serde::Deserialize;
 use temporal_sdk::{ActContext, ActivityError};
-use tracing::info;
 
 #[derive(Deserialize, Debug)]
 struct Response {

--- a/activities-examples/src/bin/client.rs
+++ b/activities-examples/src/bin/client.rs
@@ -1,14 +1,15 @@
 use helper::client_ext::ClientExt;
 use helper::get_client;
+use log::info;
 use nanoid::nanoid;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use tokio::join;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/activities-examples/src/bin/main.rs
+++ b/activities-examples/src/bin/main.rs
@@ -4,6 +4,7 @@ use dotenv::dotenv;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await?;
     Ok(())

--- a/child-workflows/Cargo.toml
+++ b/child-workflows/Cargo.toml
@@ -15,8 +15,8 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true
 

--- a/child-workflows/src/bin/client.rs
+++ b/child-workflows/src/bin/client.rs
@@ -1,13 +1,14 @@
 use helper::client_ext::ClientExt;
 use helper::get_client;
+use log::info;
 use nanoid::nanoid;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/child-workflows/src/bin/main.rs
+++ b/child-workflows/src/bin/main.rs
@@ -4,6 +4,7 @@ use dotenv::dotenv;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await?;
     Ok(())

--- a/continue-as-new/Cargo.toml
+++ b/continue-as-new/Cargo.toml
@@ -14,8 +14,8 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true
 

--- a/continue-as-new/src/bin/client.rs
+++ b/continue-as-new/src/bin/client.rs
@@ -6,6 +6,7 @@ use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/continue-as-new/src/bin/main.rs
+++ b/continue-as-new/src/bin/main.rs
@@ -4,6 +4,7 @@ use dotenv::dotenv;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await?;
     Ok(())

--- a/continue-as-new/src/workflow.rs
+++ b/continue-as-new/src/workflow.rs
@@ -1,9 +1,9 @@
 use helper::payload_ext::PayloadExt;
+use log::info;
 use std::time::Duration;
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core_protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution;
 use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
-use tracing::info;
 
 pub async fn looping_workflow(ctx: WfContext) -> WorkflowResult<()> {
     let iteration = ctx.get_args()[0].deserialize::<u32>()?;

--- a/hello-world/Cargo.toml
+++ b/hello-world/Cargo.toml
@@ -14,7 +14,7 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true

--- a/hello-world/src/bin/client.rs
+++ b/hello-world/src/bin/client.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
 use helper::client_ext::ClientExt;
 use helper::util::client::get_client;
+use log::info;
 use nanoid::nanoid;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk_core::protos::coresdk::AsJsonPayloadExt;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/hello-world/src/bin/main.rs
+++ b/hello-world/src/bin/main.rs
@@ -4,6 +4,7 @@ use hello_world::worker;
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await
 }

--- a/hello-world/src/workflows.rs
+++ b/hello-world/src/workflows.rs
@@ -1,10 +1,10 @@
 use crate::activities::greet;
 use helper::activity_resolution_ext::ActivityResolutionExt;
 use helper::wf_context_ext::{ProxyActivityOptions, WfContextExt};
+use log::info;
 use std::time::Duration;
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core::protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
-use tracing::info;
 
 /// A workflow that simply calls an activity
 pub async fn example(ctx: WfContext) -> WorkflowResult<String> {

--- a/helper/Cargo.toml
+++ b/helper/Cargo.toml
@@ -6,13 +6,13 @@ authors.workspace = true
 version.workspace = true
 
 [dependencies]
-gethostname = "0.5"
 temporal-sdk.workspace = true
 temporal-client.workspace = true
 temporal-sdk-core.workspace = true
 temporal-sdk-core-api.workspace = true
 temporal-sdk-core-protos.workspace = true
 
+gethostname = "0.5"
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/schedules/Cargo.toml
+++ b/schedules/Cargo.toml
@@ -34,8 +34,8 @@ anyhow.workspace = true
 
 dotenv.workspace = true
 helper.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true
 uuid.workspace = true

--- a/schedules/src/activities/add_reminder_to_database.rs
+++ b/schedules/src/activities/add_reminder_to_database.rs
@@ -1,5 +1,5 @@
+use log::info;
 use temporal_sdk::{ActContext, ActivityError};
-use tracing::info;
 
 pub async fn add_reminder_to_database(_: ActContext, _: String) -> Result<(), ActivityError> {
     info!("Adding reminder record to the database");

--- a/schedules/src/activities/notify_user.rs
+++ b/schedules/src/activities/notify_user.rs
@@ -1,5 +1,5 @@
+use log::info;
 use temporal_sdk::{ActContext, ActivityError};
-use tracing::info;
 
 pub async fn notify_user(_: ActContext, text: String) -> Result<(), ActivityError> {
     info!("Notifying user {}", text);

--- a/schedules/src/bin/delete_schedule.rs
+++ b/schedules/src/bin/delete_schedule.rs
@@ -1,11 +1,12 @@
 use helper::get_client;
+use log::info;
 use temporal_client::{WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core::protos::temporal::api::workflowservice::v1::DeleteScheduleRequest;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
 

--- a/schedules/src/bin/go_faster.rs
+++ b/schedules/src/bin/go_faster.rs
@@ -1,16 +1,17 @@
 use chrono::Duration;
 use helper::get_client;
+use log::info;
 use temporal_client::{WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core::protos::temporal::api::schedule::v1::{IntervalSpec, Schedule};
 use temporal_sdk_core::protos::temporal::api::workflowservice::v1::{
     DescribeScheduleRequest, UpdateScheduleRequest,
 };
-use tracing::info;
 use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
     let schedule_id = "sample-schedule";

--- a/schedules/src/bin/main.rs
+++ b/schedules/src/bin/main.rs
@@ -3,6 +3,7 @@ use schedules::worker;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await
 }

--- a/schedules/src/bin/pause_schedule.rs
+++ b/schedules/src/bin/pause_schedule.rs
@@ -1,13 +1,14 @@
 use helper::get_client;
+use log::info;
 use temporal_client::{WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core::protos::temporal::api::schedule::v1::SchedulePatch;
 use temporal_sdk_core::protos::temporal::api::workflowservice::v1::PatchScheduleRequest;
-use tracing::info;
 use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
 

--- a/schedules/src/bin/start_schedules.rs
+++ b/schedules/src/bin/start_schedules.rs
@@ -1,5 +1,6 @@
 use chrono::Duration;
 use helper::get_client;
+use log::info;
 use nanoid::nanoid;
 use temporal_client::{WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core::protos::coresdk::AsJsonPayloadExt;
@@ -12,12 +13,12 @@ use temporal_sdk_core::protos::temporal::api::schedule::v1::{
 use temporal_sdk_core::protos::temporal::api::taskqueue::v1::TaskQueue;
 use temporal_sdk_core::protos::temporal::api::workflow::v1::NewWorkflowExecutionInfo;
 use temporal_sdk_core::protos::temporal::api::workflowservice::v1::CreateScheduleRequest;
-use tracing::info;
 use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
     let workflow_id = format!("workflow-id-{}", nanoid!());

--- a/schedules/src/bin/unpause_schedule.rs
+++ b/schedules/src/bin/unpause_schedule.rs
@@ -1,13 +1,14 @@
 use helper::get_client;
+use log::info;
 use temporal_client::{WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core::protos::temporal::api::schedule::v1::SchedulePatch;
 use temporal_sdk_core::protos::temporal::api::workflowservice::v1::PatchScheduleRequest;
-use tracing::info;
 use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
 

--- a/search-attributes/Cargo.toml
+++ b/search-attributes/Cargo.toml
@@ -15,8 +15,8 @@ helper.workspace = true
 
 anyhow.workspace = true
 dotenv.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+log.workspace = true
+env_logger.workspace = true
 tokio.workspace = true
 nanoid.workspace = true
 serde_json.workspace = true

--- a/search-attributes/src/bin/client.rs
+++ b/search-attributes/src/bin/client.rs
@@ -2,16 +2,17 @@ use anyhow::Result;
 use chrono::Local;
 use helper::client_ext::ClientExt;
 use helper::util::client::get_client;
+use log::info;
 use nanoid::nanoid;
 use search_attributes::SearchAttributesWrapper;
 use std::collections::HashMap;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk_core::protos::coresdk::AsJsonPayloadExt;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let client = get_client().await?;
 

--- a/search-attributes/src/bin/client_operator_serivce.rs
+++ b/search-attributes/src/bin/client_operator_serivce.rs
@@ -1,13 +1,14 @@
 use helper::util::client::get_client;
+use log::info;
 use std::collections::HashMap;
 use temporal_client::OperatorService;
 use temporal_sdk_core_protos::temporal::api::enums::v1::IndexedValueType;
 use temporal_sdk_core_protos::temporal::api::operatorservice::v1::AddSearchAttributesRequest;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let mut client = get_client().await?;
 

--- a/search-attributes/src/bin/main.rs
+++ b/search-attributes/src/bin/main.rs
@@ -4,6 +4,7 @@ use search_attributes::worker;
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     worker::start_worker().await
 }


### PR DESCRIPTION
Custom `tracing subscriber` may conflict with temporal-sdk, except `custom-logger`, that build on purpose